### PR TITLE
Correct placement of wei2912's surname.

### DIFF
--- a/book/lysa.ltx
+++ b/book/lysa.ltx
@@ -5,7 +5,7 @@
 \author{
   \anauthor{Peter Harpending}{pharpend2@gmail.com}
   \anauthor{Anton Golov}{jesyspa@gmail.com}
-  \anauthor{Wei En Ng}{wei2912.supp0rt@gmail.com}
+  \anauthor{Ng Wei En}{wei2912.supp0rt@gmail.com}
   % Randy Brown \\
 }
 


### PR DESCRIPTION
Chinese surnames should be at the front of a name.
