### PR TITLE
Manually add known host, because Travis doesn't do it for PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ deploy:
     tags: true
     repo: learnmath/lysa
     all_branches: true
-addons:
-  ssh_known_hosts: 184.164.72.39
 after_success:
   - openssl aes-256-cbc -K $encrypted_6d2a7d4982c7_key -iv $encrypted_6d2a7d4982c7_iv
     -in deploy_rsa.enc -out deploy_rsa -d
   - chmod 600 deploy_rsa
+  - ssh-keyscan -t rsa,dsa -H $HOST 2>&1 | tee -a $HOME/.ssh/known_hosts
   - scp -i deploy_rsa book/lysa.pdf $USER@$HOST:html/lysa-$TRAVIS_BUILD_NUMBER.pdf
 notifications:
   irc: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ after_success:
     -in deploy_rsa.enc -out deploy_rsa -d
   - chmod 600 deploy_rsa
   - ssh-keyscan -t rsa,dsa -H $HOST 2>&1 | tee -a $HOME/.ssh/known_hosts
-  - scp -i deploy_rsa book/lysa.pdf $USER@$HOST:html/lysa-$TRAVIS_BUILD_NUMBER.pdf
+  - scp -i deploy_rsa book/lysa.pdf $USER@$HOST:html/lysa-$TRAVIS_COMMIT.pdf
 notifications:
   irc: 
     channels:


### PR DESCRIPTION
This causes deploys to stall.
