### PR TITLE
Make FDL an appendix

### DIFF
--- a/book/fdl.ltx
+++ b/book/fdl.ltx
@@ -582,4 +582,4 @@ free software license, such as the GNU General Public License,
 to permit their use in free software.
 
 %---------------------------------------------------------------------
-\end{document}
+% \end{document}

--- a/book/lysa.ltx
+++ b/book/lysa.ltx
@@ -20,6 +20,7 @@
 \usepackage{amsmath}
 \usepackage{amsfonts}
 \usepackage{amssymb}
+\usepackage[toc,page]{appendix}
 \usepackage[backend=bibtex]{biblatex}
 \usepackage{fontspec}
 % \usepackage[utf8]{inputenc}
@@ -114,7 +115,10 @@
 \input{1-introduction.ltx}
 \input{2-sets-monoids.ltx}
 \input{3-special-sets.ltx}
+\begin{appendices}
 \input{fdl.ltx}
+\end{appendices}
+
 \newpage
 \printbibliography
 \end{document}


### PR DESCRIPTION
This fixes #51.

There was also an issue I meant to report that this also fixes. The FDL ended with `\end{document}` which was causing the bibliography not to get printed. This fixes that issue as well.
